### PR TITLE
feat(optional-id): allow registering items using their names/descriptions as id

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This will require all entities, use cases and repositories files.
 ### Adding Objects and Metadata
 
 *Entities*
+
 ```javascript
 // src/domain/entities/item.js
 const { entity, field } = require('@herbsjs/herbs')
@@ -45,7 +46,10 @@ module.exports =
         .entity
 ```
 
+The second parameter of the `herbarium.entities.add` function is the entity id for herbarium. It is optional and if none is provided, it uses the entity name (`Item`).
+
 *Use Cases*
+
 ```javascript
 // src/domain/usecases/item/createItem.js
 const { usecase } = require('@herbsjs/herbs')
@@ -64,7 +68,10 @@ module.exports =
         .usecase
 ```
 
+The second parameter of the `herbarium.usecases.add` function is the usecase id for herbarium. It is optional and if none is provided, it uses the usecase description (`Create Item`).
+
 *Repository*
+
 ```javascript
 const { herbarium } = require('@herbsjs/herbarium')
 const { Repository } = require("@herbsjs/herbs2knex")
@@ -83,10 +90,12 @@ module.exports =
         .repository
 ```
 
+The second parameter of the `herbarium.repositories.add` function is the repository id for herbarium. It is optional and if none is provided, it uses the repository class name (`ItemRepository`).
+
 ### Consuming Objects
 
-
 *all*
+
 ```javascript
 const entities = herbarium.entities.all
 const usecases = herbarium.usecases.all
@@ -94,12 +103,19 @@ const repositories = herbarium.repositories.all
 ```
 
 *findBy*
+
 ```javascript
-const usecases = herbarium.usecases
-    .findBy({ operation: [herbarium.crud.create, herbarium.crud.update, herbarium.crud.delete] })
+const usecases = herbarium.usecases.findBy({
+  operation: [
+    herbarium.crud.create,
+    herbarium.crud.update,
+    herbarium.crud.delete,
+  ],
+})
 ```
 
 *get by id*
+
 ```javascript
 const entity = herbarium.entities.get(1)
 const usecase = herbarium.usecases.get("a")
@@ -108,8 +124,8 @@ const repository = herbarium.repositories.get(item)
 
 ## TODO
 
-- [ ] Improve Test Coverage (metadata, specialized objects, etc)
-- [ ] Default IDs - No need to inform IDs when adding a item. Use entity name or use case description.
+- [x] Improve Test Coverage (metadata, specialized objects, etc)
+- [x] Default IDs - No need to inform IDs when adding a item. Use entity name or use case description.
 
 ### Contribute
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -522,6 +522,31 @@
         }
       }
     },
+    "@herbsjs/buchu": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@herbsjs/buchu/-/buchu-1.4.0.tgz",
+      "integrity": "sha512-cTuuKixe/uqdmaIawSwo4QWhY0jxXqjUZy4v1vsl109piq7cONq7xbsyCX6D1m+Vu8/h4SPg4ZQ6ArNrW1G9RA==",
+      "dev": true,
+      "requires": {
+        "@herbsjs/gotu": "^1.1.0",
+        "@herbsjs/suma": "^1.2.0"
+      }
+    },
+    "@herbsjs/gotu": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@herbsjs/gotu/-/gotu-1.1.0.tgz",
+      "integrity": "sha512-PFyIK+yzVKSEkiI8iw/totTnX/c0RbdjpbeyFFsIqrrkKmzVP1jw6mI4AaVT4o1kqEER7Yl3M227wpY9ekCT0g==",
+      "dev": true,
+      "requires": {
+        "@herbsjs/suma": "^1.2.0"
+      }
+    },
+    "@herbsjs/suma": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@herbsjs/suma/-/suma-1.2.0.tgz",
+      "integrity": "sha512-jACOrRxt1DEyxuu234G5Roq8qTvTfa5biMDQ3cYOWstMB8GsAsuuk+prGDsa+60F5RaQ/tRyjfCtsm0KnJEwMg==",
+      "dev": true
+    },
     "@humanwhocodes/config-array": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.2.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "require-all": "^3.0.0"
   },
   "devDependencies": {
+    "@babel/eslint-parser": "^7.16.5",
+    "@herbsjs/buchu": "^1.4.0",
+    "@herbsjs/gotu": "^1.1.0",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/commit-analyzer": "^9.0.2",
     "@semantic-release/git": "^10.0.1",
@@ -42,7 +45,6 @@
     "@semantic-release/npm": "^8.0.3",
     "@semantic-release/release-notes-generator": "^10.0.3",
     "cz-conventional-changelog": "^3.3.0",
-    "semantic-release": "^18.0.1",
     "eslint": "^8.6.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.25.4",
@@ -50,7 +52,7 @@
     "mocha": "^9.1.4",
     "nyc": "^15.1.0",
     "prettier": "^2.5.1",
-    "@babel/eslint-parser": "^7.16.5"
+    "semantic-release": "^18.0.1"
   },
   "repository": {
     "type": "git",

--- a/src/entities.js
+++ b/src/entities.js
@@ -1,9 +1,16 @@
 const item = require('./list/item')
 const list = require('./list/list')
 const entities = new Map()
+const { toPascalCase } = require('./tools')
 
 const builder = (entity, id) => {
-    const defaultItem = item(id)
+    const entityId = id || toPascalCase(entity.name)
+
+    if (!entityId) {
+        throw new Error('Herbarium requires an id for this entity or an entity with a non empty name.')
+    }
+
+    const defaultItem = item(entityId)
     const entityItem = Object.assign({}, defaultItem, { entity })
     return entityItem
 }

--- a/src/entities.test.js
+++ b/src/entities.test.js
@@ -1,0 +1,33 @@
+const entities = require('./entities')
+const assert = require('assert')
+const { entity } = require('@herbsjs/gotu')
+
+describe('entities', () => {
+    it('should create an empty list', () => {
+        assert.deepEqual(entities.all, new Map())
+    })
+
+    it('should throw an error when no id is provided and the entity has no name', () => {
+        const entityWithNoName = {}
+        assert.throws(() => entities.add(entityWithNoName), /^Error: Herbarium requires an id for this entity or an entity with a non empty name.$/)
+    })
+
+    it('should create an item with the provided id and entity', () => {
+        const anEntity = entity('an entity', {})
+        const id = 'an id'
+
+        const addedItem = entities.add(anEntity, id)
+
+        assert.equal(addedItem.id, id)
+        assert.equal(addedItem.entity, anEntity)
+    })
+
+    it('should create an item with the entity name in pascalcase as id when no id is provided', () => {
+        const anEntity = entity('an entity', {})
+
+        const addedItem = entities.add(anEntity)
+
+        assert.equal(addedItem.id, 'AnEntity')
+        assert.equal(addedItem.entity, anEntity)
+    })
+})

--- a/src/list/item.test.js
+++ b/src/list/item.test.js
@@ -1,0 +1,25 @@
+const item = require('./item')
+const assert = require('assert')
+
+describe('item', () => {
+    it('should return an object with the provided id', () => {
+        const id = 'my id'
+        const createdItem = item(id)
+        assert.equal(createdItem.id, id)
+    })
+
+    context('metadata method', () => {
+        it('should return the item with the provided metadata attached to it', () => {
+            const id = 'my item id'
+            const createdItem = item(id)
+
+            const metadata = {
+                someImportantThing: true
+            }
+
+            const itemWithMetadata = createdItem.metadata(metadata)
+
+            assert.deepEqual(itemWithMetadata, { ...createdItem, ...metadata })
+        })
+    })
+})

--- a/src/repositories.test.js
+++ b/src/repositories.test.js
@@ -1,0 +1,18 @@
+const repositories = require('./repositories')
+const assert = require('assert')
+
+describe('repositories', () => {
+    it('should create an empty list', () => {
+        assert.deepEqual(repositories.all, new Map())
+    })
+
+    it('should create an item with the provided id and repository', () => {
+        class Repository { }
+        const id = 'an id'
+
+        const addedRepository = repositories.add(Repository, id)
+
+        assert.equal(addedRepository.id, id)
+        assert.equal(addedRepository.repository, Repository)
+    })
+})

--- a/src/tools/index.js
+++ b/src/tools/index.js
@@ -1,0 +1,5 @@
+const toPascalCase = require('./pascalCase')
+
+module.exports = {
+    toPascalCase
+}

--- a/src/tools/pascalCase.js
+++ b/src/tools/pascalCase.js
@@ -1,0 +1,23 @@
+const toPascalCase = (text) => {
+    if (text === null || text === undefined) {
+        return ''
+    }
+
+    const alphanumericText = text.replace(/[^a-zA-Z0-9 ]/gi, '')
+
+    if (!alphanumericText.trim()) {
+        return ''
+    }
+
+    return alphanumericText
+        .trim()
+        .split(' ')
+        .reduce((pascalCaseText, [firstLetter, ...remainingLetters]) => {
+            const upperCaseFirstLetter = firstLetter.toUpperCase()
+            const restOfTheWord = remainingLetters.join('')
+
+            return `${pascalCaseText}${upperCaseFirstLetter}${restOfTheWord}`
+        }, '')
+}
+
+module.exports = toPascalCase

--- a/src/tools/pascalCase.test.js
+++ b/src/tools/pascalCase.test.js
@@ -1,0 +1,46 @@
+const toPascalCase = require('./pascalCase')
+const assert = require('assert')
+
+describe('pascalCase', () => {
+    it('should return empty string when the text is null', () => {
+        const result = toPascalCase(null)
+        assert.equal(result, '')
+    })
+
+    it('should return empty string when the text is undefined', () => {
+        const result = toPascalCase(undefined)
+        assert.equal(result, '')
+    })
+
+    it('should remove non alphanumeric characters from the text', () => {
+        const letters = 'abcdefghijklmnopqrstuvwxyz'
+        const upperCaseLetters = letters.toUpperCase()
+        const numbers = '0123456789'
+        const nonAlphanumericChacaters = '!@#$%^&*()_+[]\\|:>.,<?/'
+
+        const alphanumericText = `${numbers}${letters}${upperCaseLetters}`
+
+        const text = `${alphanumericText}${nonAlphanumericChacaters}`
+
+        const result = toPascalCase(text)
+        assert.equal(result, alphanumericText)
+    })
+
+    it('should return empty string when the text has no alphanumeric characters', () => {
+        const nonAlphanumericChacaters = '!@#$%^  &*(   )_+[]\\|  :>.,<?/  '
+        const result = toPascalCase(nonAlphanumericChacaters)
+        assert.equal(result, '')
+    })
+
+    it('should make the first character uppercase', () => {
+        const text = 'text'
+        const [firstLetter] = toPascalCase(text)
+        assert.equal(firstLetter, 'T')
+    })
+
+    it('should make every character after a `space` uppercase', () => {
+        const text = 'text with spaces'
+        const result = toPascalCase(text)
+        assert.equal(result, 'TextWithSpaces')
+    })
+})

--- a/src/usecases.js
+++ b/src/usecases.js
@@ -1,9 +1,16 @@
 const item = require('./list/item')
 const list = require('./list/list')
 const usecases = new Map()
+const { toPascalCase } = require('./tools')
 
 const builder = (usecase, id) => {
-    const defaultItem = item(id)
+    const usecaseId = id || toPascalCase(usecase.description)
+
+    if (!usecaseId) {
+        throw new Error('Herbarium requires an id for this usecase or an usecase with non empty description.')
+    }
+
+    const defaultItem = item(usecaseId)
     const usecaseItem = Object.assign({}, defaultItem, {
         usecase,
         operation: undefined,

--- a/src/usecases.test.js
+++ b/src/usecases.test.js
@@ -1,0 +1,33 @@
+const usecases = require('./usecases')
+const assert = require('assert')
+const { usecase } = require('@herbsjs/buchu')
+
+describe('usecases', () => {
+    it('should create an empty list', () => {
+        assert.deepEqual(usecases.all, new Map())
+    })
+
+    it('should throw an error when no id is provided and the usecase has no description', () => {
+        assert.throws(() => usecases.add(class { }), /^Error: Herbarium requires an id for this usecase or an usecase with non empty description.$/)
+    })
+
+    it('should create an item with the provided id and usecase', () => {
+        const myUsecase = usecase('My Usecase', { })
+
+        const id = 'an id'
+
+        const addedUsecase = usecases.add(myUsecase, id)
+
+        assert.equal(addedUsecase.id, id)
+        assert.equal(addedUsecase.usecase, myUsecase)
+    })
+
+    it('should create an item with the usecase description in pascalcase as id when no id is provided', () => {
+        const myUsecaseWithDescription = usecase('my usecase description', {})
+
+        const addedUsecase = usecases.add(myUsecaseWithDescription)
+
+        assert.equal(addedUsecase.id, 'MyUsecaseDescription')
+        assert.equal(addedUsecase.usecase, myUsecaseWithDescription)
+    })
+})


### PR DESCRIPTION
added the possibility to use the entity name, repository name or usecase description as item id when
no id is provided

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Updated the entities builder to use the entity name if the id parameter is not provided. Throws an error if both are falsy.
2. Updated the repositories builder to use the repository class name if the id parameter is not provided. Throws an error if both are falsy.
3. Updated the usecases builder to use the usecase description if the id parameter is not provided. Throws an error if both are falsy.
4. Implemented unit tests

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request
- [x] Remember to check if code coverage decrease, if so, please implement the necessary tests

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
